### PR TITLE
chore(Dockerfile): add git to the base image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 VERSION := $(shell git describe --tags --exact-match 2>/dev/null || echo latest)
-REGISTRY ?= quay.io/
-IMAGE_PREFIX ?= deis
+REGISTRY ?=
+IMAGE_PREFIX ?= hephy
 IMAGE := ${REGISTRY}${IMAGE_PREFIX}/base:${VERSION}
 
 build:

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -11,6 +11,7 @@ RUN sed -i -e 's/^deb-src/#deb-src/' /etc/apt/sources.list && \
         bash \
         ca-certificates \
         curl \
+        git \
         net-tools \
         procps \
         gnupg && \


### PR DESCRIPTION
Ran into some errors on builder since git is missing from bionic images.